### PR TITLE
Integrate tl::expected library to make code exception-free

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rdparty/cpp/sqlite3"]
 	path = 3rdparty/cpp/sqlite3
 	url = https://github.com/ndsev/zserio-sqlite3
+[submodule "3rdparty/tl-expected"]
+	path = 3rdparty/tl-expected
+	url = https://github.com/TartanLlama/expected.git

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -17,6 +17,9 @@ cmake_minimum_required(VERSION 3.15.0)
 
 project(ZserioCpp17Runtime)
 
+# Add tl::expected submodule
+add_subdirectory(${CMAKE_SOURCE_DIR}/../../3rdparty/tl-expected)
+
 set(ZSERIO_CPP17_RUNTIME_LIB_SRCS
     zserio/pmr/Any.h
     zserio/pmr/BitBuffer.h
@@ -147,4 +150,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/zserio FILES ${ZSERIO_CPP17_RUNTIM
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/../../3rdparty/tl-expected/include)
+
+# Link against tl::expected
+target_link_libraries(${PROJECT_NAME} expected)

--- a/runtime/src/zserio/BitStreamReader.cpp
+++ b/runtime/src/zserio/BitStreamReader.cpp
@@ -291,65 +291,103 @@ inline void loadCacheNext(ReaderContext& ctx, uint8_t numBits)
     }
 }
 
-/** Unchecked implementation of readUnsignedBits. */
-inline BaseType readUnsignedBitsImpl(ReaderContext& ctx, uint8_t numBits)
+/** Implementation of readUnsignedBits. */
+inline expected<BaseType> readUnsignedBitsImpl(ReaderContext& ctx, uint8_t numBits)
 {
-    BaseType value = 0;
-    if (ctx.cacheNumBits < numBits)
+    try
     {
-        // read all remaining cache bits
-        value = ctx.cache & MASK_TABLE[ctx.cacheNumBits];
-        ctx.bitIndex += ctx.cacheNumBits;
-        numBits = static_cast<uint8_t>(numBits - ctx.cacheNumBits);
-
-        // load next piece of buffer into cache
-        loadCacheNext(ctx, numBits);
-
-        // add the remaining bits to the result
-        // if numBits is sizeof(BaseType) * 8 here, value is already 0 (see MASK_TABLE[0])
-        if (numBits < sizeof(BaseType) * 8)
+        BaseType value = 0;
+        if (ctx.cacheNumBits < numBits)
         {
-            value <<= numBits;
-        }
-    }
-    value |= ((ctx.cache >> static_cast<uint8_t>(ctx.cacheNumBits - numBits)) & MASK_TABLE[numBits]);
-    ctx.cacheNumBits = static_cast<uint8_t>(ctx.cacheNumBits - numBits);
-    ctx.bitIndex += numBits;
+            // read all remaining cache bits
+            value = ctx.cache & MASK_TABLE[ctx.cacheNumBits];
+            ctx.bitIndex += ctx.cacheNumBits;
+            numBits = static_cast<uint8_t>(numBits - ctx.cacheNumBits);
 
-    return value;
+            // load next piece of buffer into cache
+            loadCacheNext(ctx, numBits);
+
+            // add the remaining bits to the result
+            // if numBits is sizeof(BaseType) * 8 here, value is already 0 (see MASK_TABLE[0])
+            if (numBits < sizeof(BaseType) * 8)
+            {
+                value <<= numBits;
+            }
+        }
+        value |= ((ctx.cache >> static_cast<uint8_t>(ctx.cacheNumBits - numBits)) & MASK_TABLE[numBits]);
+        ctx.cacheNumBits = static_cast<uint8_t>(ctx.cacheNumBits - numBits);
+        ctx.bitIndex += numBits;
+
+        return value;
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-/** Unchecked version of readSignedBits. */
-inline BaseSignedType readSignedBitsImpl(ReaderContext& ctx, uint8_t numBits)
+/** Implementation of readSignedBits. */
+inline expected<BaseSignedType> readSignedBitsImpl(ReaderContext& ctx, uint8_t numBits)
 {
-    static const uint8_t typeSize = sizeof(BaseSignedType) * 8;
-    BaseType value = readUnsignedBitsImpl(ctx, numBits);
-
-    // Skip the signed overflow correction if numBits == typeSize.
-    // In that case, the value that comes out the readBits function
-    // is already correct.
-    if (numBits != 0 && numBits < typeSize &&
-            (value >= (static_cast<BaseType>(1) << static_cast<uint8_t>(numBits - 1))))
+    try
     {
-        value -= static_cast<BaseType>(1) << numBits;
-    }
+        static const uint8_t typeSize = sizeof(BaseSignedType) * 8;
+        auto valueResult = readUnsignedBitsImpl(ctx, numBits);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
 
-    return static_cast<BaseSignedType>(value);
+        BaseType value = *valueResult;
+
+        // Skip the signed overflow correction if numBits == typeSize.
+        // In that case, the value that comes out the readBits function
+        // is already correct.
+        if (numBits != 0 && numBits < typeSize &&
+                (value >= (static_cast<BaseType>(1) << static_cast<uint8_t>(numBits - 1))))
+        {
+            value -= static_cast<BaseType>(1) << numBits;
+        }
+
+        return static_cast<BaseSignedType>(value);
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
 #ifndef ZSERIO_RUNTIME_64BIT
-/** Unchecked implementation of readUnsignedBits64. Always reads > 32bit! */
-inline uint64_t readUnsignedBits64Impl(ReaderContext& ctx, uint8_t numBits)
+/** Implementation of readUnsignedBits64. Always reads > 32bit! */
+inline expected<uint64_t> readUnsignedBits64Impl(ReaderContext& ctx, uint8_t numBits)
 {
-    // read the first 32 bits
-    numBits = static_cast<uint8_t>(numBits - 32);
-    uint64_t value = readUnsignedBitsImpl(ctx, 32);
+    try
+    {
+        // read the first 32 bits
+        numBits = static_cast<uint8_t>(numBits - 32);
+        auto valueResult = readUnsignedBitsImpl(ctx, 32);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
 
-    // add the remaining bits
-    value <<= numBits;
-    value |= readUnsignedBitsImpl(ctx, numBits);
+        uint64_t value = static_cast<uint64_t>(*valueResult);
 
-    return value;
+        // add the remaining bits
+        value <<= numBits;
+        auto remainingResult = readUnsignedBitsImpl(ctx, numBits);
+        if (!remainingResult)
+        {
+            return tl::make_unexpected(remainingResult.error());
+        }
+        value |= static_cast<uint64_t>(*remainingResult);
+
+        return value;
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 #endif
 
@@ -391,452 +429,848 @@ BitStreamReader::BitStreamReader(const uint8_t* buffer, size_t bufferBitSize, Bi
         m_context(Span<const uint8_t>(buffer, (bufferBitSize + 7) / 8), bufferBitSize)
 {}
 
-uint32_t BitStreamReader::readUnsignedBits32(uint8_t numBits)
+expected<uint32_t> BitStreamReader::readUnsignedBits32(uint8_t numBits)
 {
     checkNumBits(numBits);
 
-    return static_cast<uint32_t>(readUnsignedBitsImpl(m_context, numBits));
+    try
+    {
+        return static_cast<uint32_t>(readUnsignedBitsImpl(m_context, numBits));
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-uint64_t BitStreamReader::readUnsignedBits64(uint8_t numBits)
+expected<uint64_t> BitStreamReader::readUnsignedBits64(uint8_t numBits)
 {
     checkNumBits64(numBits);
 
-#ifdef ZSERIO_RUNTIME_64BIT
-    return readUnsignedBitsImpl(m_context, numBits);
-#else
-    if (numBits <= 32)
+    try
     {
+#ifdef ZSERIO_RUNTIME_64BIT
         return readUnsignedBitsImpl(m_context, numBits);
-    }
+#else
+        if (numBits <= 32)
+        {
+            return readUnsignedBitsImpl(m_context, numBits);
+        }
 
-    return readUnsignedBits64Impl(m_context, numBits);
+        return readUnsignedBits64Impl(m_context, numBits);
 #endif
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-int64_t BitStreamReader::readSignedBits64(uint8_t numBits)
+expected<int64_t> BitStreamReader::readSignedBits64(uint8_t numBits)
 {
     checkNumBits64(numBits);
 
+    try
+    {
 #ifdef ZSERIO_RUNTIME_64BIT
-    return readSignedBitsImpl(m_context, numBits);
-#else
-    if (numBits <= 32)
-    {
         return readSignedBitsImpl(m_context, numBits);
-    }
+#else
+        if (numBits <= 32)
+        {
+            return readSignedBitsImpl(m_context, numBits);
+        }
 
-    int64_t value = static_cast<int64_t>(readUnsignedBits64Impl(m_context, numBits));
+        auto valueResult = readSignedBitsImpl(m_context, numBits);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
 
-    // Skip the signed overflow correction if numBits == 64.
-    // In that case, the value that comes out the readBits function
-    // is already correct.
-    const bool needsSignExtension =
-            numBits < 64 && (static_cast<uint64_t>(value) >= (UINT64_C(1) << (numBits - 1U)));
-    if (needsSignExtension)
-    {
-        value = static_cast<int64_t>(static_cast<uint64_t>(value) - (UINT64_C(1) << numBits));
-    }
-
-    return value;
+        return *valueResult;
 #endif
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-int32_t BitStreamReader::readSignedBits32(uint8_t numBits)
+expected<int32_t> BitStreamReader::readSignedBits32(uint8_t numBits)
 {
     checkNumBits(numBits);
 
-    return static_cast<int32_t>(readSignedBitsImpl(m_context, numBits));
-}
-
-Bool BitStreamReader::readBool()
-{
-    return readUnsignedBitsImpl(m_context, 1) != 0;
-}
-
-VarInt16 BitStreamReader::readVarInt16()
-{
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    const bool sign = (byte & VARINT_SIGN_1) != 0;
-    uint16_t result = byte & VARINT_BYTE_1;
-    if ((byte & VARINT_HAS_NEXT_1) == 0)
+    try
     {
+        return static_cast<int32_t>(readSignedBitsImpl(m_context, numBits));
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
+}
+
+expected<Bool> BitStreamReader::readBool()
+{
+    try
+    {
+        auto result = readUnsignedBitsImpl(m_context, 1);
+        if (!result)
+        {
+            return tl::make_unexpected(result.error());
+        }
+
+        return result.value() != 0;
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
+}
+
+expected<VarInt16> BitStreamReader::readVarInt16()
+{
+    try
+    {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        const bool sign = (byte & VARINT_SIGN_1) != 0;
+        uint16_t result = byte & VARINT_BYTE_1;
+        if ((byte & VARINT_HAS_NEXT_1) == 0)
+        {
+            return sign ? static_cast<int16_t>(-result) : static_cast<int16_t>(result);
+        }
+
+        result = static_cast<uint16_t>(result << 8U);
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        result = static_cast<uint16_t>(result | *secondByteResult); // byte 2
         return sign ? static_cast<int16_t>(-result) : static_cast<int16_t>(result);
     }
-
-    result = static_cast<uint16_t>(result << 8U);
-    result = static_cast<uint16_t>(result | readUnsignedBitsImpl(m_context, 8)); // byte 2
-    return sign ? static_cast<int16_t>(-result) : static_cast<int16_t>(result);
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-VarInt32 BitStreamReader::readVarInt32()
+expected<VarInt32> BitStreamReader::readVarInt32()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    const bool sign = (byte & VARINT_SIGN_1) != 0;
-    uint32_t result = byte & VARINT_BYTE_1;
-    if ((byte & VARINT_HAS_NEXT_1) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        const bool sign = (byte & VARINT_SIGN_1) != 0;
+        uint32_t result = byte & VARINT_BYTE_1;
+        if ((byte & VARINT_HAS_NEXT_1) == 0)
+        {
+            return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*fourthByteResult); // byte 4
         return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
+    catch(const std::exception& e)
     {
-        return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    return sign ? -static_cast<int32_t>(result) : static_cast<int32_t>(result);
 }
 
-VarInt64 BitStreamReader::readVarInt64()
+expected<VarInt64> BitStreamReader::readVarInt64()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    const bool sign = (byte & VARINT_SIGN_1) != 0;
-    uint64_t result = byte & VARINT_BYTE_1;
-    if ((byte & VARINT_HAS_NEXT_1) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        const bool sign = (byte & VARINT_SIGN_1) != 0;
+        uint64_t result = byte & VARINT_BYTE_1;
+        if ((byte & VARINT_HAS_NEXT_1) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = static_cast<uint64_t>(result) << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fourthByteResult); // byte 4
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto fifthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fifthByteResult)
+        {
+            return tl::make_unexpected(fifthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fifthByteResult); // byte 5
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto sixthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!sixthByteResult)
+        {
+            return tl::make_unexpected(sixthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*sixthByteResult); // byte 6
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto seventhByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!seventhByteResult)
+        {
+            return tl::make_unexpected(seventhByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*seventhByteResult); // byte 7
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto eighthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!eighthByteResult)
+        {
+            return tl::make_unexpected(eighthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*eighthByteResult); // byte 8
         return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
+    catch(const std::exception& e)
     {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = static_cast<uint64_t>(result) << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 5
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 6
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 7
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 8
-    return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
 }
 
-VarInt BitStreamReader::readVarInt()
+expected<VarInt> BitStreamReader::readVarInt()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    const bool sign = (byte & VARINT_SIGN_1) != 0;
-    uint64_t result = byte & VARINT_BYTE_1;
-    if ((byte & VARINT_HAS_NEXT_1) == 0)
+    try
     {
-        return sign ? (result == 0 ? INT64_MIN : -static_cast<int64_t>(result)) : static_cast<int64_t>(result);
-    }
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        const bool sign = (byte & VARINT_SIGN_1) != 0;
+        uint64_t result = byte & VARINT_BYTE_1;
+        if ((byte & VARINT_HAS_NEXT_1) == 0)
+        {
+            return sign ? (result == 0 ? INT64_MIN : -static_cast<int64_t>(result)) : static_cast<int64_t>(result);
+        }
 
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fourthByteResult); // byte 4
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto fifthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fifthByteResult)
+        {
+            return tl::make_unexpected(fifthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fifthByteResult); // byte 5
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto sixthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!sixthByteResult)
+        {
+            return tl::make_unexpected(sixthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*sixthByteResult); // byte 6
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto seventhByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!seventhByteResult)
+        {
+            return tl::make_unexpected(seventhByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*seventhByteResult); // byte 7
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto eighthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!eighthByteResult)
+        {
+            return tl::make_unexpected(eighthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*eighthByteResult); // byte 8
+        result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
+        if ((byte & VARINT_HAS_NEXT_N) == 0)
+        {
+            return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        }
+
+        auto ninthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!ninthByteResult)
+        {
+            return tl::make_unexpected(ninthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*ninthByteResult); // byte 9
         return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
+    catch(const std::exception& e)
     {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 5
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 6
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 7
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 8
-    result = result << 7U | static_cast<uint8_t>(byte & VARINT_BYTE_N);
-    if ((byte & VARINT_HAS_NEXT_N) == 0)
-    {
-        return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 9
-    return sign ? -static_cast<int64_t>(result) : static_cast<int64_t>(result);
 }
 
-VarUInt16 BitStreamReader::readVarUInt16()
+expected<VarUInt16> BitStreamReader::readVarUInt16()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    uint16_t result = byte & VARUINT_BYTE;
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        uint16_t result = byte & VARUINT_BYTE;
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        result = static_cast<uint16_t>(result << 8U);
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        result = static_cast<uint16_t>(result | *secondByteResult); // byte 2
         return result;
     }
-
-    result = static_cast<uint16_t>(result << 8U);
-    result = static_cast<uint16_t>(result | readUnsignedBitsImpl(m_context, 8)); // byte 2
-    return result;
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-VarUInt32 BitStreamReader::readVarUInt32()
+expected<VarUInt32> BitStreamReader::readVarUInt32()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    uint32_t result = byte & VARUINT_BYTE;
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        uint32_t result = byte & VARUINT_BYTE;
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*fourthByteResult); // byte 4
         return result;
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    catch(const std::exception& e)
     {
-        return result;
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    return result;
 }
 
-VarUInt64 BitStreamReader::readVarUInt64()
+expected<VarUInt64> BitStreamReader::readVarUInt64()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    uint64_t result = byte & VARUINT_BYTE;
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        uint64_t result = byte & VARUINT_BYTE;
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fourthByteResult); // byte 4
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fifthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fifthByteResult)
+        {
+            return tl::make_unexpected(fifthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fifthByteResult); // byte 5
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto sixthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!sixthByteResult)
+        {
+            return tl::make_unexpected(sixthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*sixthByteResult); // byte 6
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto seventhByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!seventhByteResult)
+        {
+            return tl::make_unexpected(seventhByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*seventhByteResult); // byte 7
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto eighthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!eighthByteResult)
+        {
+            return tl::make_unexpected(eighthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*eighthByteResult); // byte 8
         return result;
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    catch(const std::exception& e)
     {
-        return result;
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 5
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 6
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 7
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 8
-    return result;
 }
 
-VarUInt BitStreamReader::readVarUInt()
+expected<VarUInt> BitStreamReader::readVarUInt()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    uint64_t result = byte & VARUINT_BYTE;
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        uint64_t result = byte & VARUINT_BYTE;
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fourthByteResult); // byte 4
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fifthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fifthByteResult)
+        {
+            return tl::make_unexpected(fifthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fifthByteResult); // byte 5
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto sixthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!sixthByteResult)
+        {
+            return tl::make_unexpected(sixthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*sixthByteResult); // byte 6
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto seventhByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!seventhByteResult)
+        {
+            return tl::make_unexpected(seventhByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*seventhByteResult); // byte 7
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto eighthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!eighthByteResult)
+        {
+            return tl::make_unexpected(eighthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*eighthByteResult); // byte 8
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto ninthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!ninthByteResult)
+        {
+            return tl::make_unexpected(ninthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*ninthByteResult); // byte 9
         return result;
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    catch(const std::exception& e)
     {
-        return result;
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 5
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 6
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 7
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 8
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 9
-    return result;
 }
 
-VarSize BitStreamReader::readVarSize()
+expected<VarSize> BitStreamReader::readVarSize()
 {
-    uint8_t byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 1
-    uint32_t result = byte & VARUINT_BYTE;
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    try
     {
+        auto byteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!byteResult)
+        {
+            return tl::make_unexpected(byteResult.error());
+        }
+        uint8_t byte = static_cast<uint8_t>(*byteResult); // byte 1
+        uint32_t result = byte & VARUINT_BYTE;
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto secondByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!secondByteResult)
+        {
+            return tl::make_unexpected(secondByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*secondByteResult); // byte 2
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto thirdByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!thirdByteResult)
+        {
+            return tl::make_unexpected(thirdByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*thirdByteResult); // byte 3
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fourthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fourthByteResult)
+        {
+            return tl::make_unexpected(fourthByteResult.error());
+        }
+        byte = static_cast<uint8_t>(*fourthByteResult); // byte 4
+        result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
+        if ((byte & VARUINT_HAS_NEXT) == 0)
+        {
+            return result;
+        }
+
+        auto fifthByteResult = readUnsignedBitsImpl(m_context, 8);
+        if (!fifthByteResult)
+        {
+            return tl::make_unexpected(fifthByteResult.error());
+        }
+        result = result << 8U | static_cast<uint8_t>(*fifthByteResult); // byte 5
+        if (result > VARSIZE_MAX_VALUE)
+        {
+            return tl::make_unexpected(Error::create("BitStreamReader: Read value '")
+                    << result << "' is out of range for varsize type!");
+        }
+
         return result;
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 2
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
+    catch(const std::exception& e)
     {
-        return result;
+        return tl::make_unexpected(Error::create(e.what()));
     }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 3
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    byte = static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 4
-    result = result << 7U | static_cast<uint8_t>(byte & VARUINT_BYTE);
-    if ((byte & VARUINT_HAS_NEXT) == 0)
-    {
-        return result;
-    }
-
-    result = result << 8U | static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8)); // byte 5
-    if (result > VARSIZE_MAX_VALUE)
-    {
-        throw CppRuntimeException("BitStreamReader: Read value '")
-                << result << "' is out of range for varsize type!";
-    }
-
-    return result;
 }
 
-Float16 BitStreamReader::readFloat16()
+expected<Float16> BitStreamReader::readFloat16()
 {
-    const uint16_t halfPrecisionFloatValue = static_cast<uint16_t>(readUnsignedBitsImpl(m_context, 16));
+    try
+    {
+        auto valueResult = readUnsignedBitsImpl(m_context, 16);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
 
-    return convertUInt16ToFloat(halfPrecisionFloatValue);
+        const uint16_t halfPrecisionFloatValue = static_cast<uint16_t>(*valueResult);
+
+        return convertUInt16ToFloat(halfPrecisionFloatValue);
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-Float32 BitStreamReader::readFloat32()
+expected<Float32> BitStreamReader::readFloat32()
 {
-    const uint32_t singlePrecisionFloatValue = static_cast<uint32_t>(readUnsignedBitsImpl(m_context, 32));
+    try
+    {
+        auto valueResult = readUnsignedBitsImpl(m_context, 32);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
 
-    return convertUInt32ToFloat(singlePrecisionFloatValue);
+        const uint32_t singlePrecisionFloatValue = static_cast<uint32_t>(*valueResult);
+
+        return convertUInt32ToFloat(singlePrecisionFloatValue);
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
-Float64 BitStreamReader::readFloat64()
+expected<Float64> BitStreamReader::readFloat64()
 {
+    try
+    {
 #ifdef ZSERIO_RUNTIME_64BIT
-    const uint64_t doublePrecisionFloatValue = static_cast<uint64_t>(readUnsignedBitsImpl(m_context, 64));
+        auto valueResult = readUnsignedBitsImpl(m_context, 64);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
+        const uint64_t doublePrecisionFloatValue = static_cast<uint64_t>(*valueResult);
 #else
-    const uint64_t doublePrecisionFloatValue = readUnsignedBits64Impl(m_context, 64);
+        auto valueResult = readUnsignedBits64Impl(m_context, 64);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
+        const uint64_t doublePrecisionFloatValue = *valueResult;
 #endif
 
-    return convertUInt64ToDouble(doublePrecisionFloatValue);
+        return convertUInt64ToDouble(doublePrecisionFloatValue);
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
 void BitStreamReader::setBitPosition(BitPosType position)
@@ -865,9 +1299,22 @@ void BitStreamReader::alignTo(size_t alignment)
     }
 }
 
-uint8_t BitStreamReader::readByte()
+expected<uint8_t> BitStreamReader::readByte()
 {
-    return static_cast<uint8_t>(readUnsignedBitsImpl(m_context, 8));
+    try
+    {
+        auto valueResult = readUnsignedBitsImpl(m_context, 8);
+        if (!valueResult)
+        {
+            return tl::make_unexpected(valueResult.error());
+        }
+
+        return static_cast<uint8_t>(*valueResult);
+    }
+    catch(const std::exception& e)
+    {
+        return tl::make_unexpected(Error::create(e.what()));
+    }
 }
 
 } // namespace zserio

--- a/runtime/src/zserio/BitStreamReader.h
+++ b/runtime/src/zserio/BitStreamReader.h
@@ -10,6 +10,7 @@
 #include "zserio/RebindAlloc.h"
 #include "zserio/String.h"
 #include "zserio/Types.h"
+#include "zserio/Expected.h"
 
 namespace zserio
 {
@@ -114,139 +115,145 @@ public:
      *
      * \param numBits Number of bits to read.
      *
-     * \return Read bits.
+     * \return expected<uint32_t> containing error if reading fails.
      */
-    uint32_t readUnsignedBits32(uint8_t numBits = 32);
+    expected<uint32_t> readUnsignedBits32(uint8_t numBits = 32);
 
     /**
      * Reads unsigned bits up to 64-bits.
      *
      * \param numBits Number of bits to read.
      *
-     * \return Read bits.
+     * \return expected<uint64_t> containing error if reading fails.
      */
-    uint64_t readUnsignedBits64(uint8_t numBits = 64);
+    expected<uint64_t> readUnsignedBits64(uint8_t numBits = 64);
 
     /**
      * Reads signed bits up to 32-bits.
      *
      * \param numBits Number of bits to read.
      *
-     * \return Read bits.
+     * \return expected<int32_t> containing error if reading fails.
      */
-    int32_t readSignedBits32(uint8_t numBits = 32);
+    expected<int32_t> readSignedBits32(uint8_t numBits = 32);
 
     /**
      * Reads signed bits up to 64-bits.
      *
      * \param numBits Number of bits to read.
      *
-     * \return Read bits.
+     * \return expected<int64_t> containing error if reading fails.
      */
-    int64_t readSignedBits64(uint8_t numBits = 64);
+    expected<int64_t> readSignedBits64(uint8_t numBits = 64);
 
     /**
      * Reads bool as a single bit.
      *
-     * \return Read bool value.
+     * \return expected<Bool> containing error if reading fails.
      */
-    Bool readBool();
+    expected<Bool> readBool();
 
     /**
      * Reads signed variable integer up to 16 bits.
      *
-     * \return Read varint16.
+     * \return expected<VarInt16> containing error if reading fails.
      */
-    VarInt16 readVarInt16();
+    expected<VarInt16> readVarInt16();
 
     /**
      * Reads signed variable integer up to 32 bits.
      *
-     * \return Read varint32.
+     * \return expected<VarInt32> containing error if reading fails.
      */
-    VarInt32 readVarInt32();
+    expected<VarInt32> readVarInt32();
 
     /**
      * Reads signed variable integer up to 32 bits.
      *
-     * \return Read VarInt64.
+     * \return expected<VarInt64> containing error if reading fails.
      */
-    VarInt64 readVarInt64();
+    expected<VarInt64> readVarInt64();
 
     /**
      * Reads signed variable integer up to 72 bits.
      *
-     * \return Read varint.
+     * \return expected<VarInt> containing error if reading fails.
      */
-    VarInt readVarInt();
+    expected<VarInt> readVarInt();
 
     /**
      * Read unsigned variable integer up to 16 bits.
      *
-     * \return Read varuint16.
+     * \return expected<VarUInt16> containing error if reading fails.
      */
-    VarUInt16 readVarUInt16();
+    expected<VarUInt16> readVarUInt16();
 
     /**
      * Read unsigned variable integer up to 32 bits.
      *
-     * \return Read varuint32.
+     * \return expected<VarUInt32> containing error if reading fails.
      */
-    VarUInt32 readVarUInt32();
+    expected<VarUInt32> readVarUInt32();
 
     /**
      * Read unsigned variable integer up to 64 bits.
      *
-     * \return Read varuint64.
+     * \return expected<VarUInt64> containing error if reading fails.
      */
-    VarUInt64 readVarUInt64();
+    expected<VarUInt64> readVarUInt64();
 
     /**
      * Read unsigned variable integer up to 72 bits.
      *
-     * \return Read varuint.
+     * \return expected<VarUInt> containing error if reading fails.
      */
-    VarUInt readVarUInt();
+    expected<VarUInt> readVarUInt();
 
     /**
      * Read variable size integer up to 40 bits.
      *
-     * \return Read varsize.
+     * \return expected<VarSize> containing error if reading fails.
      */
-    VarSize readVarSize();
+    expected<VarSize> readVarSize();
 
     /**
      * Reads 16-bit float.
      *
-     * \return Read float16.
+     * \return expected<Float16> containing error if reading fails.
      */
-    Float16 readFloat16();
+    expected<Float16> readFloat16();
 
     /**
      * Reads 32-bit float.
      *
-     * \return Read float32.
+     * \return expected<Float32> containing error if reading fails.
      */
-    Float32 readFloat32();
+    expected<Float32> readFloat32();
 
     /**
      * Reads 64-bit float double.
      *
-     * \return Read float64.
+     * \return expected<Float64> containing error if reading fails.
      */
-    Float64 readFloat64();
+    expected<Float64> readFloat64();
 
     /**
      * Reads bytes.
      *
      * \param alloc Allocator to use.
      *
-     * \return Read bytes as a vector.
+     * \return expected<BasicBytes<ALLOC>> containing error if reading fails.
      */
     template <typename ALLOC = std::allocator<uint8_t>>
-    BasicBytes<ALLOC> readBytes(const ALLOC& alloc = ALLOC())
+    expected<BasicBytes<ALLOC>> readBytes(const ALLOC& alloc = ALLOC())
     {
-        const size_t len = static_cast<size_t>(readVarSize());
+        auto lenResult = readVarSize();
+        if (!lenResult)
+        {
+            return tl::unexpected(lenResult.error());
+        }
+
+        const size_t len = static_cast<size_t>(*lenResult);
         const BitPosType beginBitPosition = getBitPosition();
         if ((beginBitPosition & 0x07U) != 0)
         {
@@ -255,7 +262,12 @@ public:
             value.reserve(len);
             for (size_t i = 0; i < len; ++i)
             {
-                value.push_back(readByte());
+                auto byteResult = readByte();
+                if (!byteResult)
+                {
+                    return tl::unexpected(byteResult.error());
+                }
+                value.push_back(*byteResult);
             }
             return value;
         }
@@ -273,12 +285,18 @@ public:
      *
      * \param alloc Allocator to use.
      *
-     * \return Read string.
+     * \return expected<BasicString<ALLOC>> containing error if reading fails.
      */
     template <typename ALLOC = std::allocator<char>>
-    BasicString<ALLOC> readString(const ALLOC& alloc = ALLOC())
+    expected<BasicString<ALLOC>> readString(const ALLOC& alloc = ALLOC())
     {
-        const size_t len = static_cast<size_t>(readVarSize());
+        auto lenResult = readVarSize();
+        if (!lenResult)
+        {
+            return tl::unexpected(lenResult.error());
+        }
+
+        const size_t len = static_cast<size_t>(*lenResult);
         const BitPosType beginBitPosition = getBitPosition();
         if ((beginBitPosition & 0x07U) != 0)
         {
@@ -287,8 +305,13 @@ public:
             value.reserve(len);
             for (size_t i = 0; i < len; ++i)
             {
+                auto byteResult = readByte();
+                if (!byteResult)
+                {
+                    return tl::unexpected(byteResult.error());
+                }
                 const char readCharacter = std::char_traits<char>::to_char_type(
-                        static_cast<std::char_traits<char>::int_type>(readByte()));
+                        static_cast<std::char_traits<char>::int_type>(*byteResult));
                 value.push_back(readCharacter);
             }
             return value;
@@ -307,12 +330,19 @@ public:
      *
      * \param alloc Allocator to use.
      *
-     * \return Read bit buffer.
+     * \return expected<BasicBitBuffer<RebindAlloc<ALLOC, uint8_t>>> containing error if reading fails.
      */
     template <typename ALLOC = std::allocator<uint8_t>>
-    BasicBitBuffer<RebindAlloc<ALLOC, uint8_t>> readBitBuffer(const ALLOC& allocator = ALLOC())
+    expected<BasicBitBuffer<RebindAlloc<ALLOC, uint8_t>>> readBitBuffer(const ALLOC& allocator = ALLOC())
     {
-        const size_t bitSize = static_cast<size_t>(readVarSize());
+
+        auto bitSizeResult = readVarSize();
+        if (!bitSizeResult)
+        {
+            return tl::unexpected(bitSizeResult.error());
+        }
+        const size_t bitSize = static_cast<size_t>(*bitSizeResult);
+
         const size_t numBytesToRead = bitSize / 8;
         const uint8_t numRestBits = static_cast<uint8_t>(bitSize - numBytesToRead * 8);
         BasicBitBuffer<RebindAlloc<ALLOC, uint8_t>> bitBuffer(bitSize, allocator);
@@ -324,7 +354,12 @@ public:
             // we are not aligned to byte
             for (Span<uint8_t>::iterator it = buffer.begin(); it != itEnd; ++it)
             {
-                *it = static_cast<uint8_t>(readUnsignedBits32(8));
+                auto byteResult = readUnsignedBits32(8);
+                if (!byteResult)
+                {
+                    return tl::unexpected(byteResult.error());
+                }
+                *it = static_cast<uint8_t>(*byteResult);
             }
         }
         else
@@ -337,7 +372,12 @@ public:
 
         if (numRestBits > 0)
         {
-            *itEnd = static_cast<uint8_t>(readUnsignedBits32(numRestBits) << (8U - numRestBits));
+            auto restBitsResult = readUnsignedBits32(numRestBits);
+            if (!restBitsResult)
+            {
+                return tl::unexpected(restBitsResult.error());
+            }
+            *itEnd = static_cast<uint8_t>(*restBitsResult << (8U - numRestBits));
         }
 
         return bitBuffer;
@@ -378,7 +418,7 @@ public:
     }
 
 private:
-    uint8_t readByte();
+    expected<uint8_t> readByte();
 
     ReaderContext m_context;
 };

--- a/runtime/src/zserio/BitStreamWriter.cpp
+++ b/runtime/src/zserio/BitStreamWriter.cpp
@@ -344,165 +344,399 @@ BitStreamWriter::BitStreamWriter(Span<uint8_t> buffer, size_t bufferBitSize) :
     }
 }
 
-void BitStreamWriter::writeUnsignedBits32(uint32_t data, uint8_t numBits)
+expected<void> BitStreamWriter::writeUnsignedBits32(uint32_t data, uint8_t numBits)
 {
     if (numBits == 0 || numBits > sizeof(uint32_t) * 8 || data > MAX_U32_VALUES[numBits])
     {
-        throw CppRuntimeException("BitStreamWriter: Writing of ")
-                << numBits << "-bits value '" << data << "' failed!";
+        return tl::make_unexpected(Error::WRITE_ERROR);
     }
 
-    writeUnsignedBits32Impl(data, numBits);
+
+    auto result = writeUnsignedBits32Impl(data, numBits);
+    if (!result)
+    {
+        return result.error();
+    }
+
+    return {};
 }
 
-void BitStreamWriter::writeUnsignedBits64(uint64_t data, uint8_t numBits)
+expected<void> BitStreamWriter::writeUnsignedBits64(uint64_t data, uint8_t numBits)
 {
     if (numBits == 0 || numBits > sizeof(uint64_t) * 8 || data > MAX_U64_VALUES[numBits])
     {
-        throw CppRuntimeException("BitStreamWriter: Writing of ")
-                << numBits << "-bits value '" << data << "' failed!";
+        return tl::make_unexpected(Error::WRITE_ERROR);
     }
 
-    writeUnsignedBits64Impl(data, numBits);
+
+
+    auto result = writeUnsignedBits64Impl(data, numBits);
+    if (!result)
+    {
+        return result.error();
+    }
+
+
+    return {};
 }
 
-void BitStreamWriter::writeSignedBits32(int32_t data, uint8_t numBits)
+expected<void> BitStreamWriter::writeSignedBits32(int32_t data, uint8_t numBits)
 {
     if (numBits == 0 || numBits > sizeof(int32_t) * 8 || data < MIN_I32_VALUES[numBits] ||
             data > MAX_I32_VALUES[numBits])
     {
-        throw CppRuntimeException("BitStreamWriter: Writing of ")
-                << numBits << "-bits value '" << data << "' failed!";
+        return tl::make_unexpected(Error::WRITE_ERROR);
     }
 
-    writeUnsignedBits32Impl(static_cast<uint32_t>(data) & MAX_U32_VALUES[numBits], numBits);
+
+
+
+    auto result = writeUnsignedBits32Impl(static_cast<uint32_t>(data) & MAX_U32_VALUES[numBits], numBits);
+    if (!result)
+    {
+        return result.error();
+    }
+
+
+
+    return {};
 }
 
-void BitStreamWriter::writeSignedBits64(int64_t data, uint8_t numBits)
+expected<void> BitStreamWriter::writeSignedBits64(int64_t data, uint8_t numBits)
 {
     if (numBits == 0 || numBits > sizeof(int64_t) * 8 || data < MIN_I64_VALUES[numBits] ||
             data > MAX_I64_VALUES[numBits])
     {
-        throw CppRuntimeException("BitStreamWriter: Writing of ")
-                << numBits << "-bits value '" << data << "' failed!";
+        return tl::make_unexpected(Error::WRITE_ERROR);
     }
 
-    writeUnsignedBits64Impl(static_cast<uint64_t>(data) & MAX_U64_VALUES[numBits], numBits);
+
+
+
+
+    auto result = writeUnsignedBits64Impl(static_cast<uint64_t>(data) & MAX_U64_VALUES[numBits], numBits);
+    if (!result)
+    {
+        return result.error();
+    }
+
+
+
+
+    return {};
 }
 
-void BitStreamWriter::writeBool(Bool data)
+expected<void> BitStreamWriter::writeBool(Bool data)
 {
-    writeUnsignedBits32Impl((data ? 1 : 0), 1);
+
+
+    auto result = writeUnsignedBits32Impl((data ? 1 : 0), 1);
+    if (!result)
+    {
+        return result.error();
+    }
+
+
+    return {};
 }
 
-void BitStreamWriter::writeVarInt16(VarInt16 data)
+expected<void> BitStreamWriter::writeVarInt16(VarInt16 data)
 {
-    writeSignedVarNum(data, 2, detail::bitSizeOf(data) / 8);
+    auto result = writeSignedVarNum(data, 2, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
 }
 
-void BitStreamWriter::writeVarInt32(VarInt32 data)
+expected<void> BitStreamWriter::writeVarInt32(VarInt32 data)
 {
-    writeSignedVarNum(data, 4, detail::bitSizeOf(data) / 8);
+    auto result = writeSignedVarNum(data, 4, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
 }
 
-void BitStreamWriter::writeVarInt64(VarInt64 data)
+expected<void> BitStreamWriter::writeVarInt64(VarInt64 data)
 {
-    writeSignedVarNum(data, 8, detail::bitSizeOf(data) / 8);
+    auto result = writeSignedVarNum(data, 8, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
 }
 
-void BitStreamWriter::writeVarInt(VarInt data)
+expected<void> BitStreamWriter::writeVarInt(VarInt data)
 {
     if (data == INT64_MIN)
     {
-        writeUnsignedBits32Impl(0x80, 8); // INT64_MIN is encoded as -0
-    }
-    else
-    {
-        writeSignedVarNum(data, 9, detail::bitSizeOf(data) / 8);
-    }
-}
-
-void BitStreamWriter::writeVarUInt16(VarUInt16 data)
-{
-    writeUnsignedVarNum(data, 2, detail::bitSizeOf(data) / 8);
-}
-
-void BitStreamWriter::writeVarUInt32(VarUInt32 data)
-{
-    writeUnsignedVarNum(data, 4, detail::bitSizeOf(data) / 8);
-}
-
-void BitStreamWriter::writeVarUInt64(VarUInt64 data)
-{
-    writeUnsignedVarNum(data, 8, detail::bitSizeOf(data) / 8);
-}
-
-void BitStreamWriter::writeVarUInt(VarUInt data)
-{
-    writeUnsignedVarNum(data, 9, detail::bitSizeOf(data) / 8);
-}
-
-void BitStreamWriter::writeVarSize(VarSize data)
-{
-    writeUnsignedVarNum(data, 5, detail::bitSizeOf(data) / 8);
-}
-
-void BitStreamWriter::writeFloat16(Float16 data)
-{
-    const uint16_t halfPrecisionFloat = convertFloatToUInt16(data);
-    writeUnsignedBits32Impl(halfPrecisionFloat, 16);
-}
-
-void BitStreamWriter::writeFloat32(Float32 data)
-{
-    const uint32_t singlePrecisionFloat = convertFloatToUInt32(data);
-    writeUnsignedBits32Impl(singlePrecisionFloat, 32);
-}
-
-void BitStreamWriter::writeFloat64(Float64 data)
-{
-    const uint64_t doublePrecisionFloat = convertDoubleToUInt64(data);
-    writeUnsignedBits64(doublePrecisionFloat, 64);
-}
-
-void BitStreamWriter::writeBytes(BytesView data)
-{
-    const VarSize len = fromCheckedValue<VarSize>(convertSizeToUInt32(data.size()));
-    writeVarSize(len);
-
-    const BitPosType beginBitPosition = getBitPosition();
-    if ((beginBitPosition & 0x07U) != 0)
-    {
-        // we are not aligned to byte
-        for (size_t i = 0; i < len; ++i)
+        auto result = writeUnsignedBits32Impl(0x80, 8);
+        if (!result)
         {
-            writeUnsignedBits32Impl(data[i], 8);
+            return result.error();
         }
     }
     else
     {
-        // we are aligned to bytes
-        setBitPosition(beginBitPosition + len * 8);
-        if (hasWriteBuffer())
+        auto result = writeSignedVarNum(data, 9, detail::bitSizeOf(data) / 8);
+        if (!result)
         {
-            (void)std::copy(data.begin(), data.end(), m_buffer.begin() + beginBitPosition / 8);
+            return result.error();
         }
     }
+    return {};
+}
 }
 
-void BitStreamWriter::writeString(std::string_view data)
+expected<void> BitStreamWriter::writeVarUInt16(VarUInt16 data)
 {
-    const VarSize len = fromCheckedValue<VarSize>(convertSizeToUInt32(data.size()));
-    writeVarSize(len);
-
-    const BitPosType beginBitPosition = getBitPosition();
-    if ((beginBitPosition & 0x07U) != 0)
+    auto result = writeUnsignedVarNum(data, 2, detail::bitSizeOf(data) / 8);
+    if (!result)
     {
-        // we are not aligned to byte
-        for (size_t i = 0; i < len; ++i)
+        return result.error();
+    }
+    return {};
+}
+
+expected<void> BitStreamWriter::writeVarUInt32(VarUInt32 data)
+{
+    auto result = writeUnsignedVarNum(data, 4, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
+}
+
+expected<void> BitStreamWriter::writeVarUInt64(VarUInt64 data)
+{
+    auto result = writeUnsignedVarNum(data, 8, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
+}
+
+expected<void> BitStreamWriter::writeVarUInt(VarUInt data)
+{
+    auto result = writeUnsignedVarNum(data, 9, detail::bitSizeOf(data) / 8);
+    if (!result)
+    {
+        return result.error();
+    }
+    return {};
+}
+
+expected<void> BitStreamWriter::writeVarSize(VarSize data)
+{
+    try
+    {
+        auto result = writeUnsignedVarNum(data, 5, detail::bitSizeOf(data) / 8);
+        if (!result)
         {
-            // TODO[Mi-L@]: can we use unchecked here?!
-            writeUnsignedBits32(static_cast<uint8_t>(std::char_traits<char>::to_int_type(data[i])), 8);
+            return result.error();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+    return {};
+}
+
+
+
+}
+
+expected<void> BitStreamWriter::writeFloat16(Float16 data)
+{
+    try
+    {
+        const uint16_t halfPrecisionFloat = convertFloatToUInt16(data);
+
+        auto result = writeUnsignedBits32Impl(halfPrecisionFloat, 16);
+        if (!result)
+        {
+            return result.error();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+    return {};
+}
+
+
+
+    return {};
+
+
+}
+
+expected<void> BitStreamWriter::writeFloat32(Float32 data)
+{
+    try
+    {
+        const uint32_t singlePrecisionFloat = convertFloatToUInt32(data);
+
+        auto result = writeUnsignedBits32Impl(singlePrecisionFloat, 32);
+        if (!result)
+        {
+            return result.error();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+    return {};
+}
+
+
+
+
+    return {};
+
+
+
+}
+
+expected<void> BitStreamWriter::writeFloat64(Float64 data)
+{
+    try
+    {
+        const uint64_t doublePrecisionFloat = convertDoubleToUInt64(data);
+
+        auto result = writeUnsignedBits64(doublePrecisionFloat, 64);
+        if (!result)
+        {
+            return result.error();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+    return {};
+}
+
+
+
+
+
+    return {};
+
+
+
+
+}
+
+expected<void> BitStreamWriter::writeBytes(BytesView data)
+{
+    try
+    {
+        const VarSize len = fromCheckedValue<VarSize>(convertSizeToUInt32(data.size()));
+
+        auto result = writeVarSize(len);
+        if (!result)
+        {
+            return result.error();
+        }
+
+        const BitPosType beginBitPosition = getBitPosition();
+        if ((beginBitPosition & 0x07U) != 0)
+        {
+            // we are not aligned to byte
+            for (size_t i = 0; i < len; ++i)
+            {
+                auto byteResult = writeUnsignedBits32Impl(data[i], 8);
+                if (!byteResult)
+                {
+                    return byteResult.error();
+                }
+            }
+        }
+        else
+        {
+            // we are aligned to byte
+            const size_t numBytes = static_cast<size_t>(len);
+            if (numBytes > 0)
+            {
+                if (!writeBytesImpl(data.data(), numBytes))
+                {
+                    return tl::make_unexpected(Error::WRITE_ERROR);
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+}
+
+expected<void> BitStreamWriter::writeString(std::string_view data)
+{
+    try
+    {
+        const VarSize len = fromCheckedValue<VarSize>(convertSizeToUInt32(data.size()));
+
+        auto result = writeVarSize(len);
+        if (!result)
+        {
+            return result.error();
+        }
+
+        const BitPosType beginBitPosition = getBitPosition();
+        if ((beginBitPosition & 0x07U) != 0)
+        {
+            // we are not aligned to byte
+            for (size_t i = 0; i < len; ++i)
+            {
+                auto byteResult = writeUnsignedBits32Impl(static_cast<uint8_t>(data[i]), 8);
+                if (!byteResult)
+                {
+                    return byteResult.error();
+                }
+            }
+        }
+        else
+        {
+            // we are aligned to byte
+            const size_t numBytes = static_cast<size_t>(len);
+            if (numBytes > 0)
+            {
+                if (!writeBytesImpl(reinterpret_cast<const uint8_t*>(data.data()), numBytes))
+                {
+                    return tl::make_unexpected(Error::WRITE_ERROR);
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+    
+    return {};
+}
+    }
+
+
+
+
+
         }
     }
     else
@@ -514,6 +748,9 @@ void BitStreamWriter::writeString(std::string_view data)
             (void)std::copy(data.begin(), data.begin() + len, m_buffer.data() + beginBitPosition / 8);
         }
     }
+
+    return {};
+}
 }
 
 void BitStreamWriter::setBitPosition(BitPosType position)
@@ -546,99 +783,257 @@ Span<const uint8_t> BitStreamWriter::getBuffer() const
     return m_buffer;
 }
 
-void BitStreamWriter::writeUnsignedBits32Impl(uint32_t data, uint8_t numBits)
+expected<void> BitStreamWriter::writeUnsignedBits32Impl(uint32_t data, uint8_t numBits)
 {
     if (!hasWriteBuffer())
     {
         m_bitIndex += numBits;
-        return;
+        return {};
     }
 
-    checkCapacity(m_bitIndex + numBits);
-
-    uint8_t restNumBits = numBits;
-    const uint8_t bitsUsed = m_bitIndex & 0x07U;
-    uint8_t bitsFree = static_cast<uint8_t>(8 - bitsUsed);
-    size_t byteIndex = m_bitIndex / 8;
-
-    if (restNumBits > bitsFree)
+    try
     {
-        // first part
-        const uint8_t shiftNum = static_cast<uint8_t>(restNumBits - bitsFree);
-        const uint8_t maskedByte = static_cast<uint8_t>(m_buffer[byteIndex] & ~(0xFFU >> bitsUsed));
-        m_buffer[byteIndex++] = static_cast<uint8_t>(maskedByte | (data >> shiftNum));
-        restNumBits = static_cast<uint8_t>(restNumBits - bitsFree);
+        checkCapacity(m_bitIndex + numBits);
 
-        // middle parts
-        while (restNumBits >= 8)
+        uint8_t restNumBits = numBits;
+        const uint8_t bitsUsed = m_bitIndex & 0x07U;
+        uint8_t bitsFree = static_cast<uint8_t>(8 - bitsUsed);
+        size_t byteIndex = m_bitIndex / 8;
+
+        if (restNumBits > bitsFree)
         {
-            restNumBits = static_cast<uint8_t>(restNumBits - 8);
-            m_buffer[byteIndex++] = static_cast<uint8_t>((data >> restNumBits) & MAX_U32_VALUES[8]);
+            // first part
+            const uint8_t shiftNum = static_cast<uint8_t>(restNumBits - bitsFree);
+            const uint8_t maskedByte = static_cast<uint8_t>(m_buffer[byteIndex] & ~(0xFFU >> bitsUsed));
+            m_buffer[byteIndex++] = static_cast<uint8_t>(maskedByte | (data >> shiftNum));
+            restNumBits = static_cast<uint8_t>(restNumBits - bitsFree);
+
+            // middle parts
+            while (restNumBits >= 8)
+            {
+                restNumBits = static_cast<uint8_t>(restNumBits - 8);
+                m_buffer[byteIndex++] = static_cast<uint8_t>((data >> restNumBits) & MAX_U32_VALUES[8]);
+            }
+
+            // reset bits free
+            bitsFree = 8;
         }
 
-        // reset bits free
-        bitsFree = 8;
-    }
+        // last part
+        if (restNumBits > 0)
+        {
+            const uint8_t shiftNum = static_cast<uint8_t>(bitsFree - restNumBits);
+            const uint32_t mask = MAX_U32_VALUES[restNumBits];
+            const uint8_t maskedByte = m_buffer[byteIndex] & static_cast<uint8_t>(~static_cast<uint8_t>(mask << shiftNum));
+            m_buffer[byteIndex] = static_cast<uint8_t>(maskedByte | ((data & mask) << shiftNum));
+        }
 
-    // last part
-    if (restNumBits > 0)
+        m_bitIndex += numBits;
+    }
+    catch (const std::exception& e)
     {
-        const uint8_t shiftNum = static_cast<uint8_t>(bitsFree - restNumBits);
-        const uint32_t mask = MAX_U32_VALUES[restNumBits];
-        const uint8_t maskedByte =
-                m_buffer[byteIndex] & static_cast<uint8_t>(~static_cast<uint8_t>(mask << shiftNum));
-        m_buffer[byteIndex] = static_cast<uint8_t>(maskedByte | ((data & mask) << shiftNum));
-    }
+              return tl::make_unexpected(Error::fromException(e));
+          }
 
-    m_bitIndex += numBits;
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+          return {};
+
+
+    return {};
 }
 
-inline void BitStreamWriter::writeUnsignedBits64Impl(uint64_t data, uint8_t numBits)
+          return {};
+}
+
+    return {};
+}
+
+          return {};
+}
+
+    return {};
+}
+
+          return {};
+}
+
+    return {};
+}
+
+          return {};
+}
+
+    return {};
+}
+
+          return {};
+}
+
+    return {};
+}
+    }
+    return {};
+}
+
+inline expected<void> BitStreamWriter::writeUnsignedBits64Impl(uint64_t data, uint8_t numBits)
 {
-    if (numBits <= 32)
+    try
     {
-        writeUnsignedBits32Impl(static_cast<uint32_t>(data), numBits);
+        if (numBits <= 32)
+        {
+            auto result = writeUnsignedBits32Impl(static_cast<uint32_t>(data), numBits);
+            if (!result)
+            {
+                return result.error();
+            }
+        }
+        else
+        {
+            auto result1 = writeUnsignedBits32Impl(static_cast<uint32_t>(data >> 32U), static_cast<uint8_t>(numBits - 32));
+            if (!result1)
+            {
+                return result1.error();
+            }
+
+            auto result2 = writeUnsignedBits32Impl(static_cast<uint32_t>(data), 32);
+            if (!result2)
+            {
+                return result2.error();
+            }
+        }
+
+        return {};
     }
-    else
+    catch (const std::exception& e)
     {
-        writeUnsignedBits32Impl(static_cast<uint32_t>(data >> 32U), static_cast<uint8_t>(numBits - 32));
-        writeUnsignedBits32Impl(static_cast<uint32_t>(data), 32);
+        return tl::make_unexpected(Error::fromException(e));
     }
 }
 
-inline void BitStreamWriter::writeSignedVarNum(int64_t value, size_t maxVarBytes, size_t numVarBytes)
+inline expected<void> BitStreamWriter::writeSignedVarNum(int64_t value, size_t maxVarBytes, size_t numVarBytes)
+
+inline expected<void> BitStreamWriter::writeSignedVarNum(int64_t value, size_t maxVarBytes, size_t numVarBytes)
 {
-    const uint64_t absValue = static_cast<uint64_t>(value < 0 ? -value : value);
-    writeVarNum(absValue, true, value < 0, maxVarBytes, numVarBytes);
+    try
+    {
+        const uint64_t absValue = static_cast<uint64_t>(value < 0 ? -value : value);
+
+        auto result = writeVarNum(absValue, true, value < 0, maxVarBytes, numVarBytes);
+        if (!result)
+        {
+            return result.error();
+        }
+
+        return {};
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
 }
 
-inline void BitStreamWriter::writeUnsignedVarNum(uint64_t value, size_t maxVarBytes, size_t numVarBytes)
+
+inline expected<void> BitStreamWriter::writeUnsignedVarNum(uint64_t value, size_t maxVarBytes, size_t numVarBytes)
+
+inline expected<void> BitStreamWriter::writeUnsignedVarNum(uint64_t value, size_t maxVarBytes, size_t numVarBytes)
 {
-    writeVarNum(value, false, false, maxVarBytes, numVarBytes);
+    try
+    {
+        auto result = writeVarNum(value, false, false, maxVarBytes, numVarBytes);
+        if (!result)
+        {
+            return result.error();
+        }
+
+        return {};
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
 }
 
-inline void BitStreamWriter::writeVarNum(
+
+
+
+}
+
+inline expected<void> BitStreamWriter::writeVarNum(
+
+inline expected<void> BitStreamWriter::writeVarNum(
         uint64_t value, bool hasSign, bool isNegative, size_t maxVarBytes, size_t numVarBytes)
 {
-    static const std::array<uint64_t, 8> bitMasks = {0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF};
-    const bool hasMaxByteRange = (numVarBytes == maxVarBytes);
-
-    for (size_t i = 0; i < numVarBytes; i++)
+    try
     {
-        uint8_t byte = 0x00;
-        uint8_t numBits = 8;
-        const bool hasNextByte = (i < numVarBytes - 1);
-        const bool hasSignBit = (hasSign && i == 0);
-        if (hasSignBit)
+        static const std::array<uint64_t, 8> bitMasks = {0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF};
+        const bool hasMaxByteRange = (numVarBytes == maxVarBytes);
+
+        for (size_t i = 0; i < numVarBytes; i++)
         {
-            if (isNegative)
+            uint8_t byte = 0x00;
+            uint8_t numBits = 8;
+            const bool hasNextByte = (i < numVarBytes - 1);
+            const bool hasSignBit = (hasSign && i == 0);
+            if (hasSignBit)
             {
-                byte |= 0x80U;
+                if (isNegative)
+                {
+                    byte |= 0x80U;
+                }
+                numBits--;
             }
-            numBits--;
+            if (hasNextByte)
+            {
+                numBits--;
+                const uint8_t add = static_cast<uint8_t>(0x01U << numBits);
+                byte = static_cast<uint8_t>(byte | add); // use bit 6 if signed bit is present, use bit 7 otherwise
+            }
+            else // this is the last byte
+            {
+                if (!hasMaxByteRange) // next byte indicator is not used in last byte in case of max byte range
+                {
+                    numBits--;
+                }
+            }
+
+            const size_t shiftBits = (numVarBytes - (i + 1)) * 7 + ((hasMaxByteRange && hasNextByte) ? 1 : 0);
+            const uint8_t add = static_cast<uint8_t>((value >> shiftBits) & bitMasks[numBits - 1U]);
+            byte = static_cast<uint8_t>(byte | add);
+
+            auto result = writeUnsignedBits32Impl(byte, 8);
+            if (!result)
+            {
+                return result.error();
+            }
         }
-        if (hasNextByte)
-        {
+        return {};
+    }
+    catch (const std::exception& e)
+    {
+        return tl::make_unexpected(Error::fromException(e));
+    }
+}
+
             numBits--;
             const uint8_t add = static_cast<uint8_t>(0x01U << numBits);
             byte = static_cast<uint8_t>(byte | add); // use bit 6 if signed bit is present, use bit 7 otherwise
@@ -654,8 +1049,17 @@ inline void BitStreamWriter::writeVarNum(
         const size_t shiftBits = (numVarBytes - (i + 1)) * 7 + ((hasMaxByteRange && hasNextByte) ? 1 : 0);
         const uint8_t add = static_cast<uint8_t>((value >> shiftBits) & bitMasks[numBits - 1U]);
         byte = static_cast<uint8_t>(byte | add);
-        writeUnsignedBits32Impl(byte, 8);
+
+
+        auto result = writeUnsignedBits32Impl(byte, 8);
+        if (!result)
+        {
+            return result.error();
+        }
+
+
     }
+    return {};
 }
 
 inline void BitStreamWriter::throwInsufficientCapacityException() const

--- a/runtime/src/zserio/BitStreamWriter.h
+++ b/runtime/src/zserio/BitStreamWriter.h
@@ -8,10 +8,10 @@
 
 #include "zserio/BitBuffer.h"
 #include "zserio/Bytes.h"
-#include "zserio/CppRuntimeException.h"
 #include "zserio/SizeConvertUtil.h"
 #include "zserio/String.h"
 #include "zserio/Types.h"
+#include "zserio/Expected.h"
 
 namespace zserio
 {
@@ -22,12 +22,8 @@ namespace zserio
 class BitStreamWriter
 {
 public:
-    /** Exception throw in case of insufficient capacity of the given buffer. */
-    class InsufficientCapacityException : public CppRuntimeException
-    {
-    public:
-        using CppRuntimeException::CppRuntimeException;
-    };
+    /** Error code for insufficient capacity of the given buffer. */
+    static constexpr const char* INSUFFICIENT_CAPACITY_ERROR = "Insufficient capacity";
 
     /** Type for bit position. */
     using BitPosType = size_t;
@@ -97,7 +93,7 @@ public:
      * \param data Data to write.
      * \param numBits Number of bits to write.
      */
-    void writeUnsignedBits32(uint32_t data, uint8_t numBits = 32);
+    expected<void> writeUnsignedBits32(uint32_t data, uint8_t numBits = 32);
 
     /**
      * Writes unsigned bits up to 64 bits.
@@ -105,7 +101,7 @@ public:
      * \param data Data to write.
      * \param numBits Number of bits to write.
      */
-    void writeUnsignedBits64(uint64_t data, uint8_t numBits = 64);
+    expected<void> writeUnsignedBits64(uint64_t data, uint8_t numBits = 64);
 
     /**
      * Writes signed bits up to 32 bits.
@@ -113,7 +109,7 @@ public:
      * \param data Data to write.
      * \param numBits Number of bits to write.
      */
-    void writeSignedBits32(int32_t data, uint8_t numBits = 32);
+    expected<void> writeSignedBits32(int32_t data, uint8_t numBits = 32);
 
     /**
      * Writes signed bits up to 64 bits.
@@ -121,112 +117,112 @@ public:
      * \param data Data to write.
      * \param numBits Number of bits to write.
      */
-    void writeSignedBits64(int64_t data, uint8_t numBits = 64);
+    expected<void> writeSignedBits64(int64_t data, uint8_t numBits = 64);
 
     /**
      * Writes bool as a single bit.
      *
      * \param data Bool to write.
      */
-    void writeBool(Bool data);
+    expected<void> writeBool(Bool data);
 
     /**
      * Writes signed variable integer up to 16 bits.
      *
      * \param data Varint16 to write.
      */
-    void writeVarInt16(VarInt16 data);
+    expected<void> writeVarInt16(VarInt16 data);
 
     /**
      * Writes signed variable integer up to 32 bits.
      *
      * \param data Varint32 to write.
      */
-    void writeVarInt32(VarInt32 data);
+    expected<void> writeVarInt32(VarInt32 data);
 
     /**
      * Writes signed variable integer up to 64 bits.
      *
      * \param data Varint64 to write.
      */
-    void writeVarInt64(VarInt64 data);
+    expected<void> writeVarInt64(VarInt64 data);
 
     /**
      * Writes signed variable integer up to 72 bits.
      *
      * \param data Varuint64 to write.
      */
-    void writeVarInt(VarInt data);
+    expected<void> writeVarInt(VarInt data);
 
     /**
      * Writes unsigned variable integer up to 16 bits.
      *
      * \param data Varuint16 to write.
      */
-    void writeVarUInt16(VarUInt16 data);
+    expected<void> writeVarUInt16(VarUInt16 data);
 
     /**
      * Writes unsigned variable integer up to 32 bits.
      *
      * \param data Varuint32 to write.
      */
-    void writeVarUInt32(VarUInt32 data);
+    expected<void> writeVarUInt32(VarUInt32 data);
 
     /**
      * Writes unsigned variable integer up to 64 bits.
      *
      * \param data Varuint64 to write.
      */
-    void writeVarUInt64(VarUInt64 data);
+    expected<void> writeVarUInt64(VarUInt64 data);
 
     /**
      * Writes signed variable integer up to 72 bits.
      *
      * \param data Varuint64 to write.
      */
-    void writeVarUInt(VarUInt data);
+    expected<void> writeVarUInt(VarUInt data);
 
     /**
      * Writes variable size integer up to 40 bits.
      *
      * \param data Varsize to write.
      */
-    void writeVarSize(VarSize data);
+    expected<void> writeVarSize(VarSize data);
 
     /**
      * Writes 16-bit float.
      *
      * \param data Float16 to write.
      */
-    void writeFloat16(Float16 data);
+    expected<void> writeFloat16(Float16 data);
 
     /**
      * Writes 32-bit float.
      *
      * \param data Float32 to write.
      */
-    void writeFloat32(Float32 data);
+    expected<void> writeFloat32(Float32 data);
 
     /**
      * Writes 64-bit float.
      *
      * \param data Float64 to write.
      */
-    void writeFloat64(Float64 data);
+    expected<void> writeFloat64(Float64 data);
 
     /**
      * Writes bytes.
      *
      * \param data Bytes to write.
      */
-    void writeBytes(BytesView data);
+    expected<void> writeBytes(BytesView data);
 
     /**
      * Writes UTF-8 string.
      *
      * \param data String view to write.
      */
-    void writeString(std::string_view data);
+    expected<void> writeString(std::string_view data);
 
     /**
      * Writes bit buffer.
@@ -234,7 +230,7 @@ public:
      * \param bitBuffer Bit buffer to write.
      */
     template <typename ALLOC>
-    void writeBitBuffer(const BasicBitBuffer<ALLOC>& bitBuffer)
+    expected<void> writeBitBuffer(const BasicBitBuffer<ALLOC>& bitBuffer)
     {
         const VarSize bitSize = fromCheckedValue<VarSize>(convertSizeToUInt32(bitBuffer.getBitSize()));
         writeVarSize(bitSize);
@@ -328,11 +324,11 @@ public:
     }
 
 private:
-    void writeUnsignedBits32Impl(uint32_t data, uint8_t numBits);
-    void writeUnsignedBits64Impl(uint64_t data, uint8_t numBits);
-    void writeSignedVarNum(int64_t value, size_t maxVarBytes, size_t numVarBytes);
-    void writeUnsignedVarNum(uint64_t value, size_t maxVarBytes, size_t numVarBytes);
-    void writeVarNum(uint64_t value, bool hasSign, bool isNegative, size_t maxVarBytes, size_t numVarBytes);
+    expected<void> writeUnsignedBits32Impl(uint32_t data, uint8_t numBits);
+    expected<void> writeUnsignedBits64Impl(uint64_t data, uint8_t numBits);
+    expected<void> writeSignedVarNum(int64_t value, size_t maxVarBytes, size_t numVarBytes);
+    expected<void> writeUnsignedVarNum(uint64_t value, size_t maxVarBytes, size_t numVarBytes);
+    expected<void> writeVarNum(uint64_t value, bool hasSign, bool isNegative, size_t maxVarBytes, size_t numVarBytes);
 
     void checkCapacity(size_t bitSize) const;
     void throwInsufficientCapacityException() const;
@@ -345,13 +341,13 @@ private:
 namespace detail
 {
 
-inline void write(BitStreamWriter& writer, Bool value)
+inline expected<void> write(BitStreamWriter& writer, Bool value)
 {
-    writer.writeBool(value);
+    return writer.writeBool(value);
 }
 
 template <BitSize BIT_SIZE, bool IS_SIGNED>
-void write(BitStreamWriter& writer, FixedIntWrapper<BIT_SIZE, IS_SIGNED> value)
+expected<void> write(BitStreamWriter& writer, FixedIntWrapper<BIT_SIZE, IS_SIGNED> value)
 {
     using ValueType = typename FixedIntWrapper<BIT_SIZE, IS_SIGNED>::ValueType;
 
@@ -360,127 +356,127 @@ void write(BitStreamWriter& writer, FixedIntWrapper<BIT_SIZE, IS_SIGNED> value)
     {
         if constexpr (std::is_signed_v<ValueType>)
         {
-            writer.writeSignedBits32(value, BIT_SIZE);
+            return writer.writeSignedBits32(value, BIT_SIZE);
         }
         else
         {
-            writer.writeUnsignedBits32(value, BIT_SIZE);
+            return writer.writeUnsignedBits32(value, BIT_SIZE);
         }
     }
     else
     {
         if constexpr (std::is_signed_v<ValueType>)
         {
-            writer.writeSignedBits64(value, BIT_SIZE);
+            return writer.writeSignedBits64(value, BIT_SIZE);
         }
         else
         {
-            writer.writeUnsignedBits64(value, BIT_SIZE);
+            return writer.writeUnsignedBits64(value, BIT_SIZE);
         }
     }
 }
 
-template <typename T>
+template <typename T> expected<void>
 void write(BitStreamWriter& writer, DynIntWrapper<T> value, uint8_t numBits)
 {
     if constexpr (sizeof(T) <= 4)
     {
         if constexpr (std::is_signed_v<T>)
         {
-            writer.writeSignedBits32(value, numBits);
+            return writer.writeSignedBits32(value, numBits);
         }
         else
         {
-            writer.writeUnsignedBits32(value, numBits);
+            return writer.writeUnsignedBits32(value, numBits);
         }
     }
     else
     {
         if constexpr (std::is_signed_v<T>)
         {
-            writer.writeSignedBits64(value, numBits);
+            return writer.writeSignedBits64(value, numBits);
         }
         else
         {
-            writer.writeUnsignedBits64(value, numBits);
+            return writer.writeUnsignedBits64(value, numBits);
         }
     }
 }
 
-inline void write(BitStreamWriter& writer, VarInt16 value)
+inline expected<void> write(BitStreamWriter& writer, VarInt16 value)
 {
-    writer.writeVarInt16(value);
+    return writer.writeVarInt16(value);
 }
 
-inline void write(BitStreamWriter& writer, VarInt32 value)
+inline expected<void> write(BitStreamWriter& writer, VarInt32 value)
 {
-    writer.writeVarInt32(value);
+    return writer.writeVarInt32(value);
 }
 
-inline void write(BitStreamWriter& writer, VarInt64 value)
+inline expected<void> write(BitStreamWriter& writer, VarInt64 value)
 {
-    writer.writeVarInt64(value);
+    return writer.writeVarInt64(value);
 }
 
-inline void write(BitStreamWriter& writer, VarInt value)
+inline expected<void> write(BitStreamWriter& writer, VarInt value)
 {
-    writer.writeVarInt(value);
+    return writer.writeVarInt(value);
 }
 
-inline void write(BitStreamWriter& writer, VarUInt16 value)
+inline expected<void> write(BitStreamWriter& writer, VarUInt16 value)
 {
-    writer.writeVarUInt16(value);
+    return writer.writeVarUInt16(value);
 }
 
-inline void write(BitStreamWriter& writer, VarUInt32 value)
+inline expected<void> write(BitStreamWriter& writer, VarUInt32 value)
 {
-    writer.writeVarUInt32(value);
+    return writer.writeVarUInt32(value);
 }
 
-inline void write(BitStreamWriter& writer, VarUInt64 value)
+inline expected<void> write(BitStreamWriter& writer, VarUInt64 value)
 {
-    writer.writeVarUInt64(value);
+    return writer.writeVarUInt64(value);
 }
 
-inline void write(BitStreamWriter& writer, VarUInt value)
+inline expected<void> write(BitStreamWriter& writer, VarUInt value)
 {
-    writer.writeVarUInt(value);
+    return writer.writeVarUInt(value);
 }
 
-inline void write(BitStreamWriter& writer, VarSize value)
+inline expected<void> write(BitStreamWriter& writer, VarSize value)
 {
-    writer.writeVarSize(value);
+    return writer.writeVarSize(value);
 }
 
-inline void write(BitStreamWriter& writer, Float16 value)
+inline expected<void> write(BitStreamWriter& writer, Float16 value)
 {
-    writer.writeFloat16(value);
+    return writer.writeFloat16(value);
 }
 
-inline void write(BitStreamWriter& writer, Float32 value)
+inline expected<void> write(BitStreamWriter& writer, Float32 value)
 {
-    writer.writeFloat32(value);
+    return writer.writeFloat32(value);
 }
 
-inline void write(BitStreamWriter& writer, Float64 value)
+inline expected<void> write(BitStreamWriter& writer, Float64 value)
 {
-    writer.writeFloat64(value);
+    return writer.writeFloat64(value);
 }
 
-inline void write(BitStreamWriter& writer, BytesView value)
+inline expected<void> write(BitStreamWriter& writer, BytesView value)
 {
-    writer.writeBytes(value);
+    return writer.writeBytes(value);
 }
 
-inline void write(BitStreamWriter& writer, std::string_view value)
+inline expected<void> write(BitStreamWriter& writer, std::string_view value)
 {
-    writer.writeString(value);
+    return writer.writeString(value);
 }
 
 template <typename ALLOC>
-inline void write(BitStreamWriter& writer, const BasicBitBufferView<ALLOC>& value)
+inline expected<void> write(BitStreamWriter& writer, const BasicBitBufferView<ALLOC>& value)
 {
-    writer.writeBitBuffer(value.get());
+    return writer.writeBitBuffer(value.get());
 }
 
 } // namespace detail

--- a/runtime/src/zserio/Error.h
+++ b/runtime/src/zserio/Error.h
@@ -1,0 +1,197 @@
+
+#ifndef ZSERIO_ERROR_H_INC
+#define ZSERIO_ERROR_H_INC
+
+#include <string>
+#include <variant>
+
+#include "zserio/Expected.h"
+
+namespace zserio
+{
+
+/**
+ * Base class for all Zserio errors.
+ */
+struct ZserioError
+{
+    virtual ~ZserioError() = default;
+    virtual std::string toString() const = 0;
+};
+
+/**
+ * Error representing a constraint violation.
+ */
+struct ConstraintError : public ZserioError
+{
+    std::string fieldName;
+    std::string constraint;
+
+    ConstraintError(const std::string& fieldName, const std::string& constraint)
+        : fieldName(fieldName), constraint(constraint) {}
+
+    std::string toString() const override
+    {
+        return "Constraint error: field '" + fieldName + "' violates constraint '" + constraint + "'";
+    }
+};
+
+/**
+ * Error representing an out of range value.
+ */
+struct OutOfRangeError : public ZserioError
+{
+    std::string fieldName;
+    std::string value;
+    std::string range;
+
+    OutOfRangeError(const std::string& fieldName, const std::string& value, const std::string& range)
+        : fieldName(fieldName), value(value), range(range) {}
+
+    std::string toString() const override
+    {
+        return "Out of range error: field '" + fieldName + "' with value '" + value +
+               "' is out of range '" + range + "'";
+    }
+};
+
+/**
+ * Error representing a missed optional field.
+ */
+struct MissedOptionalError : public ZserioError
+{
+    std::string fieldName;
+
+    explicit MissedOptionalError(const std::string& fieldName)
+        : fieldName(fieldName) {}
+
+    std::string toString() const override
+    {
+        return "Missed optional error: field '" + fieldName + "' is missed";
+    }
+};
+
+/**
+ * Error representing an unexpected optional field.
+ */
+struct UnexpectedOptionalError : public ZserioError
+{
+    std::string fieldName;
+
+    explicit UnexpectedOptionalError(const std::string& fieldName)
+        : fieldName(fieldName) {}
+
+    std::string toString() const override
+    {
+        return "Unexpected optional error: field '" + fieldName + "' is unexpected";
+    }
+};
+
+/**
+ * Error representing a choice case error.
+ */
+struct ChoiceCaseError : public ZserioError
+{
+    std::string choiceName;
+    std::string caseName;
+
+    ChoiceCaseError(const std::string& choiceName, const std::string& caseName)
+        : choiceName(choiceName), caseName(caseName) {}
+
+    std::string toString() const override
+    {
+        return "Choice case error: choice '" + choiceName + "' has invalid case '" + caseName + "'";
+    }
+};
+
+/**
+ * Error representing a union case error.
+ */
+struct UnionCaseError : public ZserioError
+{
+    std::string unionName;
+    std::string caseName;
+
+    UnionCaseError(const std::string& unionName, const std::string& caseName)
+        : unionName(unionName), caseName(caseName) {}
+
+    std::string toString() const override
+    {
+        return "Union case error: union '" + unionName + "' has invalid case '" + caseName + "'";
+    }
+};
+
+/**
+ * Error representing a service error.
+ */
+struct ServiceError : public ZserioError
+{
+    std::string message;
+
+    explicit ServiceError(const std::string& message)
+        : message(message) {}
+
+    std::string toString() const override
+    {
+        return "Service error: " + message;
+    }
+};
+
+/**
+ * Error representing a validation error.
+ */
+struct ValidationError : public ZserioError
+{
+    std::string message;
+
+    explicit ValidationError(const std::string& message)
+        : message(message) {}
+
+    std::string toString() const override
+    {
+        return "Validation error: " + message;
+    }
+};
+
+/**
+ * Error representing a general runtime error.
+ */
+struct RuntimeError : public ZserioError
+{
+    std::string message;
+
+    explicit RuntimeError(const std::string& message)
+        : message(message) {}
+
+    std::string toString() const override
+    {
+        return "Runtime error: " + message;
+    }
+};
+
+/**
+ * Alias for the variant type that can hold any Zserio error.
+ */
+using ZserioErrorVariant = std::variant<
+    ConstraintError,
+    OutOfRangeError,
+    MissedOptionalError,
+    UnexpectedOptionalError,
+    ChoiceCaseError,
+    UnionCaseError,
+    ServiceError,
+    ValidationError,
+    RuntimeError
+>;
+
+/**
+ * Convert a ZserioErrorVariant to a string representation.
+ */
+inline std::string toString(const ZserioErrorVariant& error)
+{
+    return std::visit([](const auto& e) -> std::string { return e.toString(); }, error);
+}
+
+} // namespace zserio
+
+#endif // ZSERIO_ERROR_H_INC

--- a/runtime/src/zserio/ErrorUtil.h
+++ b/runtime/src/zserio/ErrorUtil.h
@@ -1,0 +1,86 @@
+
+
+#ifndef ZSERIO_ERROR_UTIL_H_INC
+#define ZSERIO_ERROR_UTIL_H_INC
+
+#include "zserio/Error.h"
+
+namespace zserio
+{
+
+/**
+ * Create a ConstraintError.
+ */
+inline expected<void> makeConstraintError(std::string fieldName, std::string constraint)
+{
+    return tl::unexpected(ConstraintError(std::move(fieldName), std::move(constraint)));
+}
+
+/**
+ * Create an OutOfRangeError.
+ */
+inline expected<void> makeOutOfRangeError(std::string fieldName, std::string value, std::string range)
+{
+    return tl::unexpected(OutOfRangeError(std::move(fieldName), std::move(value), std::move(range)));
+}
+
+/**
+ * Create a MissedOptionalError.
+ */
+inline expected<void> makeMissedOptionalError(std::string fieldName)
+{
+    return tl::unexpected(MissedOptionalError(std::move(fieldName)));
+}
+
+/**
+ * Create an UnexpectedOptionalError.
+ */
+inline expected<void> makeUnexpectedOptionalError(std::string fieldName)
+{
+    return tl::unexpected(UnexpectedOptionalError(std::move(fieldName)));
+}
+
+/**
+ * Create a ChoiceCaseError.
+ */
+inline expected<void> makeChoiceCaseError(std::string choiceName, std::string caseName)
+{
+    return tl::unexpected(ChoiceCaseError(std::move(choiceName), std::move(caseName)));
+}
+
+/**
+ * Create a UnionCaseError.
+ */
+inline expected<void> makeUnionCaseError(std::string unionName, std::string caseName)
+{
+    return tl::unexpected(UnionCaseError(std::move(unionName), std::move(caseName)));
+}
+
+/**
+ * Create a ServiceError.
+ */
+inline expected<void> makeServiceError(std::string message)
+{
+    return tl::unexpected(ServiceError(std::move(message)));
+}
+
+/**
+ * Create a ValidationError.
+ */
+inline expected<void> makeValidationError(std::string message)
+{
+    return tl::unexpected(ValidationError(std::move(message)));
+}
+
+/**
+ * Create a RuntimeError.
+ */
+inline expected<void> makeRuntimeError(std::string message)
+{
+    return tl::unexpected(RuntimeError(std::move(message)));
+}
+
+} // namespace zserio
+
+#endif // ZSERIO_ERROR_UTIL_H_INC
+

--- a/runtime/src/zserio/Expected.h
+++ b/runtime/src/zserio/Expected.h
@@ -1,0 +1,18 @@
+
+#ifndef ZSERIO_EXPECTED_H_INC
+#define ZSERIO_EXPECTED_H_INC
+
+#include <expected/expected.hpp>
+
+namespace zserio
+{
+
+/**
+ * Alias for tl::expected to make it easier to use in the Zserio codebase.
+ */
+template<typename Value, typename Error = std::string>
+using expected = tl::expected<Value, Error>;
+
+} // namespace zserio
+
+#endif // ZSERIO_EXPECTED_H_INC

--- a/runtime/src/zserio/View.h
+++ b/runtime/src/zserio/View.h
@@ -6,6 +6,7 @@
 #include "zserio/BitSize.h"
 #include "zserio/BitStreamReader.h"
 #include "zserio/BitStreamWriter.h"
+#include "zserio/Expected.h"
 
 namespace zserio
 {
@@ -35,10 +36,10 @@ namespace detail
  *
  * \param view Zserio View to use for validation.
  *
- * \throw CppRuntimeException In case of any validation error.
+ * \return expected<void> containing error if validation fails.
  */
 template <typename T>
-void validate(const View<T>& view, std::string_view fieldName = "");
+expected<void> validate(const View<T>& view, std::string_view fieldName = "");
 
 /**
  * Global function for bit size provided via specialization.
@@ -88,10 +89,10 @@ BitSize initializeOffsets(const View<T>& view, BitSize bitPosition)
  * \param writer Bit stream writer to use for writing.
  * \param view Zserio View to use for writing.
  *
- * \throw CppRuntimeException In case of any write error.
+ * \return expected<void> containing error if writing fails.
  */
 template <typename T>
-void write(BitStreamWriter& writer, const View<T>& view);
+expected<void> write(BitStreamWriter& writer, const View<T>& view);
 
 /**
  * Global function for reading provided via specialization.
@@ -100,12 +101,10 @@ void write(BitStreamWriter& writer, const View<T>& view);
  * \param data Zserio Data to fill with read data.
  * \param arguments All parameters in case of Zserio parameterized type.
  *
- * \return View with read data.
- *
- * \throw CppRuntimeException In case of any read error.
+ * \return expected<View<T>> containing error if reading fails.
  */
 template <typename T, typename... ARGS>
-View<T> read(BitStreamReader& reader, T& data, ARGS...);
+expected<View<T>> read(BitStreamReader& reader, T& data, ARGS...);
 
 } // namespace detail
 


### PR DESCRIPTION
This PR integrates the tl::expected library to make the code exception-free.

Changes include:
- Added tl::expected as a Git submodule
- Updated CMake configuration to include tl::expected
- Created header files for expected-based error handling
- Modified BitStreamReader and BitStreamWriter to use tl::expected
- Updated read and write functions to handle expected return values
- Added try-catch blocks for exception handling
- Replaced throw statements with tl::make_unexpected